### PR TITLE
Hotfix/maximize photo

### DIFF
--- a/script.js
+++ b/script.js
@@ -149,7 +149,15 @@ function popupImage() {
     popUpImg.src = clickedImg.src;
     
     let angle = Number(clickedImg.name);
-    popUpImg.style.transform = `rotate(${angle}deg)`;
+    popUpImg.style.transform = `translate(-50%, -50%) rotate(${angle}deg)`;
+    popUpImg.style.width = "100%";
+    popUpImg.style.height = "auto";
+    let popUpHeight = popup.getBoundingClientRect().height;
+    let popUpImgHeight = popUpImg.getBoundingClientRect().height;
+    if (popUpImgHeight>popUpHeight){
+      popUpImg.style.width = "auto";
+      popUpImg.style.height = "100%";
+    }
 
     // 表示
     popup.classList.add('is-show');

--- a/script.js
+++ b/script.js
@@ -165,7 +165,7 @@ function popupImage() {
     // 戻る
     var blackBg = document.getElementById('js-black-bg');
 
-    closePopUp(blackBg);
+    closePopUp(popUpImg);
 
     function closePopUp(elem) {
         if (!elem) return;

--- a/script.js
+++ b/script.js
@@ -150,14 +150,37 @@ function popupImage() {
     
     let angle = Number(clickedImg.name);
     popUpImg.style.transform = `translate(-50%, -50%) rotate(${angle}deg)`;
-    popUpImg.style.width = "100%";
-    popUpImg.style.height = "auto";
+    let popUpWidth = popup.getBoundingClientRect().width;
     let popUpHeight = popup.getBoundingClientRect().height;
-    let popUpImgHeight = popUpImg.getBoundingClientRect().height;
-    if (popUpImgHeight>popUpHeight){
-      popUpImg.style.width = "auto";
-      popUpImg.style.height = "100%";
+    let popUpImgWidth = popUpImg.naturalWidth;
+    let popUpImgHeight = popUpImg.naturalHeight;
+    if (angle%180 !=0){
+      let temp;
+      temp = popUpImgWidth;
+      popUpImgWidth = popUpImgHeight;
+      popUpImgHeight = temp;
     }
+    console.log(popUpImgWidth);
+    console.log(popUpImgHeight);
+    if (popUpImgWidth/popUpImgHeight>popUpWidth/popUpHeight){
+      popUpImgHeight = popUpWidth/popUpImgWidth*popUpImgHeight;
+      popUpImgWidth = popUpWidth;
+    }else{
+      popUpImgWidth = popUpHeight/popUpImgHeight*popUpImgWidth;
+      popUpImgHeight = popUpHeight;
+    }
+    console.log(popUpImgWidth);
+    console.log(popUpImgHeight);
+    if (angle%180 !=0){
+      let temp;
+      temp = popUpImgWidth;
+      popUpImgWidth = popUpImgHeight;
+      popUpImgHeight = temp;
+    }
+    popUpImg.style.width = `${popUpImgWidth}px`;
+    popUpImg.style.height = `${popUpImgHeight}px`;
+    console.log(popUpWidth);
+    console.log(popUpHeight);
 
     // 表示
     popup.classList.add('is-show');

--- a/script.js
+++ b/script.js
@@ -141,6 +141,47 @@ dropbox.addEventListener("dragleave", dragleave);
 
 // ============================================== //
 
+function resizepopupimage(){
+  let clickedImg = document.getElementById(`img_${uniqueid}`);
+  let popup = document.getElementById('js-popup');
+  let popUpImg = document.getElementById("popUpImg");
+  let angle = Number(clickedImg.name);
+
+  //popup要素の高さ幅をピクセルで取得
+  let popUpWidth = popup.getBoundingClientRect().width;
+  let popUpHeight = popup.getBoundingClientRect().height;
+  //画像の原寸での高さ幅をピクセルで取得
+  let popUpImgWidth = popUpImg.naturalWidth;
+  let popUpImgHeight = popUpImg.naturalHeight;
+  //±90°回転の場合縦横を入れ替える
+  if (angle%180 !=0){
+    let temp;
+    temp = popUpImgWidth;
+    popUpImgWidth = popUpImgHeight;
+    popUpImgHeight = temp;
+  }
+  //縦長か横長かの分岐
+  if (popUpImgWidth/popUpImgHeight>popUpWidth/popUpHeight){
+    //横長なので横幅をpopUpに合わせる
+    popUpImgHeight = popUpWidth/popUpImgWidth*popUpImgHeight;
+    popUpImgWidth = popUpWidth;
+  }else{
+    //縦長なので縦幅をpopUpに合わせる
+    popUpImgWidth = popUpHeight/popUpImgHeight*popUpImgWidth;
+    popUpImgHeight = popUpHeight;
+  }
+  //±90°回転の場合縦横を入れ替えたのを戻す
+  if (angle%180 !=0){
+    let temp;
+    temp = popUpImgWidth;
+    popUpImgWidth = popUpImgHeight;
+    popUpImgHeight = temp;
+  }
+  //調整した画像サイズを適用
+  popUpImg.style.width = `${popUpImgWidth}px`;
+  popUpImg.style.height = `${popUpImgHeight}px`;
+}
+
 function popupImage() {
     uniqueid = this.id.slice(4,);
     let clickedImg = document.getElementById(`img_${uniqueid}`);
@@ -151,52 +192,18 @@ function popupImage() {
     let angle = Number(clickedImg.name);
     //中央に表示、回転する
     popUpImg.style.transform = `translate(-50%, -50%) rotate(${angle}deg)`;
-    //popup要素の高さ幅をピクセルで取得
-    let popUpWidth = popup.getBoundingClientRect().width;
-    let popUpHeight = popup.getBoundingClientRect().height;
-    //画像の原寸での高さ幅をピクセルで取得
-    let popUpImgWidth = popUpImg.naturalWidth;
-    let popUpImgHeight = popUpImg.naturalHeight;
-    //±90°回転の場合縦横を入れ替える
-    if (angle%180 !=0){
-      let temp;
-      temp = popUpImgWidth;
-      popUpImgWidth = popUpImgHeight;
-      popUpImgHeight = temp;
-    }
-    //縦長か横長かの分岐
-    if (popUpImgWidth/popUpImgHeight>popUpWidth/popUpHeight){
-      //横長なので横幅をpopUpに合わせる
-      popUpImgHeight = popUpWidth/popUpImgWidth*popUpImgHeight;
-      popUpImgWidth = popUpWidth;
-    }else{
-      //縦長なので縦幅をpopUpに合わせる
-      popUpImgWidth = popUpHeight/popUpImgHeight*popUpImgWidth;
-      popUpImgHeight = popUpHeight;
-    }
-    //±90°回転の場合縦横を入れ替えたのを戻す
-    if (angle%180 !=0){
-      let temp;
-      temp = popUpImgWidth;
-      popUpImgWidth = popUpImgHeight;
-      popUpImgHeight = temp;
-    }
-    //調整した画像サイズを適用
-    popUpImg.style.width = `${popUpImgWidth}px`;
-    popUpImg.style.height = `${popUpImgHeight}px`;
-
+    resizepopupimage();
     // 表示
     popup.classList.add('is-show');
-    
-    // 戻る
-    var blackBg = document.getElementById('js-black-bg');
 
     closePopUp(popUpImg);
+    window.addEventListener("resize", resizepopupimage);
 
     function closePopUp(elem) {
         if (!elem) return;
         elem.addEventListener('click', function () {
             popup.classList.remove('is-show');
+            window.removeEventListener("resize", resizepopupimage);
         });
     }
 }

--- a/script.js
+++ b/script.js
@@ -149,38 +149,41 @@ function popupImage() {
     popUpImg.src = clickedImg.src;
     
     let angle = Number(clickedImg.name);
+    //中央に表示、回転する
     popUpImg.style.transform = `translate(-50%, -50%) rotate(${angle}deg)`;
+    //popup要素の高さ幅をピクセルで取得
     let popUpWidth = popup.getBoundingClientRect().width;
     let popUpHeight = popup.getBoundingClientRect().height;
+    //画像の原寸での高さ幅をピクセルで取得
     let popUpImgWidth = popUpImg.naturalWidth;
     let popUpImgHeight = popUpImg.naturalHeight;
+    //±90°回転の場合縦横を入れ替える
     if (angle%180 !=0){
       let temp;
       temp = popUpImgWidth;
       popUpImgWidth = popUpImgHeight;
       popUpImgHeight = temp;
     }
-    console.log(popUpImgWidth);
-    console.log(popUpImgHeight);
+    //縦長か横長かの分岐
     if (popUpImgWidth/popUpImgHeight>popUpWidth/popUpHeight){
+      //横長なので横幅をpopUpに合わせる
       popUpImgHeight = popUpWidth/popUpImgWidth*popUpImgHeight;
       popUpImgWidth = popUpWidth;
     }else{
+      //縦長なので縦幅をpopUpに合わせる
       popUpImgWidth = popUpHeight/popUpImgHeight*popUpImgWidth;
       popUpImgHeight = popUpHeight;
     }
-    console.log(popUpImgWidth);
-    console.log(popUpImgHeight);
+    //±90°回転の場合縦横を入れ替えたのを戻す
     if (angle%180 !=0){
       let temp;
       temp = popUpImgWidth;
       popUpImgWidth = popUpImgHeight;
       popUpImgHeight = temp;
     }
+    //調整した画像サイズを適用
     popUpImg.style.width = `${popUpImgWidth}px`;
     popUpImg.style.height = `${popUpImgHeight}px`;
-    console.log(popUpWidth);
-    console.log(popUpHeight);
 
     // 表示
     popup.classList.add('is-show');

--- a/script.js
+++ b/script.js
@@ -196,7 +196,7 @@ function popupImage() {
     // 表示
     popup.classList.add('is-show');
 
-    closePopUp(popUpImg);
+    closePopUp(popup);
     window.addEventListener("resize", resizepopupimage);
 
     function closePopUp(elem) {

--- a/style.css
+++ b/style.css
@@ -91,11 +91,17 @@ button {
     position: absolute;
     left: 50%;
     top: 50%;
+    width: 100%;
+    height: 100%;
     transform: translate(-50%,-50%);
     z-index: 2;
 }
 
 .popup-inner img {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     width: 100%;
 }
 


### PR DESCRIPTION
ポップアップ画像のリサイズについての修正です。
画像が縦長の場合、横幅をウィンドウに合わせると縦がウィンドウからはみ出る場合があるのでどちらも収まるようにしました。
また、width,heightの設定がtransform前の高さ、幅を設定する仕様に合わせ、画像が回転しても正しい縮尺でリサイズされるようにしました。